### PR TITLE
chore(exec): set arg0 explicitly when spawning via PATH

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::io::{self, Write};
 use std::env;
+use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -101,7 +102,8 @@ fn main() {
                        let mode = metadata.permissions().mode();
                        
                        if mode & 0o111 != 0 {
-                           match Command::new(full_path)
+                           match Command::new(&full_path)
+                               .arg0(command)
                                .args(&parts[1..])
                                .status() {
                                    Ok(_) => {},


### PR DESCRIPTION
### summary

- set arg0 explicitly when spawning processes via PATH
- ensure correct argv[0] behavior for executed programs

### notes

- improves compatibility with unix program expectations
- no user-visible behavior change